### PR TITLE
Triggering change in the apex.jQuery ns when working with multiple jquery versions

### DIFF
--- a/src/main/javascript/select2-apex.js
+++ b/src/main/javascript/select2-apex.js
@@ -6,6 +6,9 @@ beCtbSelect2.events = {
 
     pageItem.on("change", function(e) {
       apex.jQuery(this).trigger("slctchange", {val:e.val, added:e.added, removed:e.removed});
+      if ($.fn.jquery !== apex.jQuery.fn.jquery){
+            apex.jQuery(this).trigger("change");
+      }
     });
     pageItem.on("select2-opening", function(e) {
       apex.jQuery(this).trigger("slctopening");


### PR DESCRIPTION
The select2 plugin triggers a change event on the source (hidden) item.
But when working with different versions of jQuery on the page, the change event of apex.jQuery ns is not triggered and cascading selectlist do not work anymore.
To fix this we can check if the versions of $ and apex.jQuery are different and still trigger the change event in the apex.jQuery ns.